### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/axelrindle/github-graphql-client/workflows/CI/badge.svg)
+![CI](https://github.com/imsky/github-graphql-client/workflows/CI/badge.svg)
 
 # GitHub GraphQL Client
 


### PR DESCRIPTION
The badge should point on this repository, not on my fork 😅 